### PR TITLE
Fix deprecated ActiveRecord syntax for count with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Mount it at a customizable path in `routes.rb`:
 
     mount Sidekiq::Monitor::Engine => '/sidekiq'
 
+Changelog
+----
+- Updated show method in `queues_controller`
+    Queues query was updated to work in Rails 5 and major, because count method with finder options was
+    deprecated (i.e `Model.where(field: value).count(group: 'status')`) from Rails 4 in favor of new syntax
+    i.e `Model.where(field: value).group('status').count`.
+
 Usage
 -----
 

--- a/app/controllers/sidekiq/monitor/api/queues_controller.rb
+++ b/app/controllers/sidekiq/monitor/api/queues_controller.rb
@@ -8,7 +8,11 @@ module Sidekiq
           queue = params[:queue]
           render json: {}, status: 404 and return if queue.blank?
 
-          status_counts = Sidekiq::Monitor::Job.where(queue: queue).count(group: 'status')
+          if ::Rails::VERSION::MAJOR >= 4
+            status_counts = Sidekiq::Monitor::Job.where(queue: queue).group('status').count
+          else
+            status_counts = Sidekiq::Monitor::Job.where(queue: queue).count(group: 'status')
+          end
           ordered_status_counts = {}
           Sidekiq::Monitor::Job.statuses.each do |status|
             ordered_status_counts[status] = status_counts.has_key?(status) ? status_counts[status] : 0


### PR DESCRIPTION
This PR fix issue with the deprecated syntax from Rails 4 for count method in ActiveRecord